### PR TITLE
add better error handling for update station

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,8 +22,6 @@ func main() {
 	var reBuildDB = flag.Bool("rebuild", false, "rebuild database")
 	flag.Parse()
 
-	// var err error
-
 	if *reBuildDB {
 		if err := buildDatabase(); err != nil {
 			log.Fatalf("build database error: ", err)
@@ -160,25 +158,36 @@ func editReview(ctx irisctx.Context) {
 }
 
 func updateStation(ctx irisctx.Context) {
+
 	defer timeLog(time.Now(), "updateStation")
+	log.Printf("%+#v\n", ctx)
 	id := ctx.Params().Get("id")
 	if id == "" {
-		ctx.Err()
+		ctx.StatusCode(iris.StatusBadRequest)
+		ctx.WriteString("bad station id " + id + " in request url")
 		return
 	}
 
 	var s Station
 	if err := ctx.ReadJSON(&s); err != nil {
-		log.Printf("error parsing json: %v\n", err)
+		log.Printf("\n\nerror parsing json: %v\n\n", err)
 		ctx.StatusCode(iris.StatusBadRequest)
 		ctx.WriteString(err.Error())
 		return
 	}
+	if s.StationID == 0 {
+		ctx.StatusCode(iris.StatusBadRequest)
+		ctx.WriteString("station id not present in request body")
+		return
+	}
+
+	log.Printf("\n\n%+#v\n\n", s)
 
 	u, err := updateStationDB(s)
 	if err != nil {
 		log.Printf("error updating staion: %v\n", err)
-		ctx.Err()
+		ctx.StatusCode(iris.StatusBadRequest)
+		ctx.WriteString("invalid station id")
 		return
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -231,23 +231,6 @@ func TestGetStationWithBadInput(t *testing.T) {
 
 }
 
-// func Test_updateStationHandler(t *testing.T) {
-// 	type args struct {
-// 		ctx irisctx.Context
-// 	}
-// 	tests := []struct {
-// 		name string
-// 		args args
-// 	}{
-// 	// TODO: Add test cases.
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			updateStationHandler(tt.args.ctx)
-// 		})
-// 	}
-// }
-
 func TestUpdateStationDB(t *testing.T) {
 
 	tests := []struct {
@@ -324,6 +307,7 @@ func TestUpdateStation(t *testing.T) {
 		content string
 	}{
 		{name: "test1", id: "1", req: Station{StationID: 1, EmptySlots: 1200}, content: "application/json", status: 200},
+		{name: "test1", id: "5364", req: Station{StationID: 5364, EmptySlots: 1200}, content: "application/json", status: 200},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -345,6 +329,7 @@ func TestUpdateStation(t *testing.T) {
 				if got.Safe != tt.req.Safe {
 					t.Errorf("expected: %v but got: %v", tt.req.Safe, got.Safe)
 				}
+				fmt.Println("GOT ", got)
 			}
 
 		})


### PR DESCRIPTION
change so that POST /api/stations{id} returns status code 400 rather than empty object on bad requests.